### PR TITLE
add missing schema permission type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASE
+
+### Fixes
+
+* Add missing `permission.type` in schema fields. `@apostrophecms/scheduled-publising` fields were missing on all pieces and pages when the module was used with `@apostrophecms-pro/advanced-permission` enabled.
+
 ## 1.0.2
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## UNRELEASE
+## UNRELEASED
 
 ### Fixes
 

--- a/modules/@apostrophecms/doc-type-scheduled-publishing/index.js
+++ b/modules/@apostrophecms/doc-type-scheduled-publishing/index.js
@@ -12,14 +12,16 @@ module.exports = {
           label: 'apostrophe:scheduledPublish',
           publishedLabel: 'apostrophe:scheduledUpdate',
           permission: {
-            action: 'publish'
+            action: 'publish',
+            type: self.__meta.name
           }
         },
         scheduledUnpublish: {
           type: 'dateAndTime',
           label: 'apostrophe:scheduledUnpublish',
           permission: {
-            action: 'publish'
+            action: 'publish',
+            type: self.__meta.name
           }
         }
       },


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Fix issue with missing scheduled publishing fields when use with advanced permission

## What are the specific steps to test this change?

1. Enable `@apostrophecms/scheduled-publishing` (`main` branch) & `@apostrophecms-pro/advanced-permission` 
2. Edit a piece or a page, `@apostrophecms/scheduled-publishing` fields must be missing
3. Try again with `@apostrophecms/scheduled-publishing` (`pro-3116-fix-when-used-with-advanced-permission` branch), the `scheduled-publishing` fields must be visible

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
